### PR TITLE
Show navigation links on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -505,15 +505,38 @@ body {
 }
 
 /* Responsive Design */
+@media (max-width: 767px) {
+    .header-nav {
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
+        height: auto;
+        padding: 1rem 0;
+        gap: 0.75rem;
+    }
+
+    .nav-menu {
+        display: flex;
+        width: 100%;
+        margin-left: 0;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .nav-link {
+        padding: 0.5rem 0.75rem;
+    }
+}
+
 @media (min-width: 768px) {
     .main-content {
         padding: 3rem 1.5rem;
     }
-    
+
     .container {
         padding: 0 1.5rem;
     }
-    
+
     .nav-menu {
         display: flex;
     }


### PR DESCRIPTION
## Summary
- make the header navigation display on small screens
- stack and space the links for easier tapping on mobile devices

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0cd2c4c148329a60d26411c2f02d7